### PR TITLE
BDOG-2681: Amend channel lookup field name on tems lookup

### DIFF
--- a/app/uk/gov/hmrc/servicemetrics/connector/SlackNotificationsConnector.scala
+++ b/app/uk/gov/hmrc/servicemetrics/connector/SlackNotificationsConnector.scala
@@ -85,8 +85,8 @@ final case class SlackNotificationResponse(
 sealed trait ChannelLookup { def by: String }
 
 final case class GithubTeam(
-  repositoryName: String,
-  by            : String = "github-team"
+  teamName: String,
+  by      : String = "github-team"
 ) extends ChannelLookup
 
 final case class OwningTeams(


### PR DESCRIPTION
Amends this error:
```
Invalid SendNotificationRequest payload: List((/channelLookup/teamName,List(JsonValidationError(List(error.path.missing),ArraySeq()))))
```